### PR TITLE
Single line change to switchcb

### DIFF
--- a/CellBase_R2013a/Functions/database_functions/cellbase/switchcb.m
+++ b/CellBase_R2013a/Functions/database_functions/cellbase/switchcb.m
@@ -32,7 +32,7 @@ if d ~= 0
     setpref('cellbase','datapath',datapath);
     %this may be annoying functionality
     %changes the path of fname to the new path
-    [pathstr,name,ext,v] = fileparts(fname);
+    [~,name,ext] = fileparts(fname);
     fname = fullfile(datapath,[name ext]);
     f = uigetfile({'*.mat','MAT-files (*.mat)'},'Select the main database file',fname);
     if f ~=0


### PR DESCRIPTION
Asks for 4 output args from fileparts, which is a MATLAB function with only three output args. I also removed unused vars. The change allowed me to run switchcb without an error where the error below occurred previously:
'Too many output arguments.'